### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Foodstream-io/etchebest/security/code-scanning/2](https://github.com/Foodstream-io/etchebest/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/ci.yml` at the workflow root (between `on` and `env`, or anywhere top-level) so it applies to all jobs that don’t override permissions. For this workflow, the minimal required permission is:

- `contents: read`

This preserves current functionality (`actions/checkout` and build steps) while ensuring least privilege and preventing future drift if repository/org defaults change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
